### PR TITLE
Add markdown paramter type and update github-issuer template

### DIFF
--- a/pkg/action/github/issuer.go
+++ b/pkg/action/github/issuer.go
@@ -32,7 +32,11 @@ var issueTemplateData string
 var issueTemplate *template.Template
 
 func init() {
-	issueTemplate = template.Must(template.New("issue").Parse(issueTemplateData))
+	funcMap := template.FuncMap{
+		"add": func(a, b int) int { return a + b },
+	}
+
+	issueTemplate = template.Must(template.New("issue").Funcs(funcMap).Parse(issueTemplateData))
 }
 
 type IssuerFactory struct{}

--- a/pkg/action/github/issuer_template.md
+++ b/pkg/action/github/issuer_template.md
@@ -1,3 +1,4 @@
+{{$countMarkdown := 0}}
 - ID: {{ .ID }}
 - Created At: {{ .CreatedAt }}
 - Schema: {{ .Schema }}
@@ -10,7 +11,18 @@
 
 | Key | Value | Type |
 |-----|-------|------|
-{{range .Params}}| {{ .Key }} | `{{ .Value }}` | {{ .Type }} |
+{{range .Params}}{{ if ne .Type "markdown" }} | {{ .Key }} | `{{ .Value }}` | {{ .Type }} |
+{{else}}{{ $countMarkdown = add $countMarkdown 1 }}{{end}}{{end}}
+
+{{ if gt $countMarkdown 0 }}
+## Comments
+
+{{range .Params}}{{ if eq .Type "markdown" }}
+### {{ .Key }}
+
+{{ .Value }}
+
+{{end}}{{end}}
 {{end}}
 
 ## Alert

--- a/pkg/action/github/issuer_test.go
+++ b/pkg/action/github/issuer_test.go
@@ -10,12 +10,63 @@ import (
 
 	"github.com/m-mizutani/alertchain/pkg/action/github"
 	"github.com/m-mizutani/alertchain/pkg/domain/model"
+	"github.com/m-mizutani/alertchain/pkg/domain/types"
 	"github.com/m-mizutani/gt"
 
 	gh "github.com/google/go-github/github"
 )
 
 func TestIssueTemplate(t *testing.T) {
+	var buf bytes.Buffer
+	gt.NoError(t, github.ExecuteTemplate(&buf, model.Alert{
+		AlertMetaData: model.AlertMetaData{
+			Title:       "blue",
+			Description: "orange",
+			Params: []model.Parameter{
+				{
+					Key:   "magic",
+					Value: "five",
+				},
+				{
+					Key:   "star",
+					Value: "light",
+				},
+				{
+					Key:   "int",
+					Value: 123,
+				},
+				{
+					Key:   "struct",
+					Value: struct{ Foo string }{Foo: "bar"},
+				},
+				{
+					Key:   "md-title",
+					Value: "*md-test*",
+					Type:  types.MarkDown,
+				},
+			},
+		},
+		Schema: "fire",
+		Raw:    `{"foo": "bar"}`,
+	}))
+
+	s := buf.String()
+	gt.B(t, strings.Contains(s, "orange")).True()
+	gt.B(t, strings.Contains(s, "| magic | `five` |")).True()
+	gt.B(t, strings.Contains(s, "| star | `light` |")).True()
+	gt.B(t, strings.Contains(s, "| int | `123` |")).True()
+	gt.B(t, strings.Contains(s, "| struct | `{bar}` |")).True()
+	gt.B(t, strings.Contains(s, `{"foo": "bar"}`)).True()
+
+	gt.B(t, strings.Contains(s, "| md-title | `*md-test*` |")).False()
+	gt.B(t, strings.Contains(s, "## Comments")).True()
+	gt.B(t, strings.Contains(s, "### md-title")).True()
+	gt.B(t, strings.Contains(s, "*md-test*")).True()
+
+	os.WriteFile("test.md", []byte(s), 0644)
+}
+
+func TestIssueTemplateNoMarkdown(t *testing.T) {
 	var buf bytes.Buffer
 	gt.NoError(t, github.ExecuteTemplate(&buf, model.Alert{
 		AlertMetaData: model.AlertMetaData{
@@ -45,12 +96,7 @@ func TestIssueTemplate(t *testing.T) {
 	}))
 
 	s := buf.String()
-	gt.B(t, strings.Contains(s, "orange")).True()
-	gt.B(t, strings.Contains(s, "| magic | `five` |")).True()
-	gt.B(t, strings.Contains(s, "| star | `light` |")).True()
-	gt.B(t, strings.Contains(s, "| int | `123` |")).True()
-	gt.B(t, strings.Contains(s, "| struct | `{bar}` |")).True()
-	gt.B(t, strings.Contains(s, `{"foo": "bar"}`)).True()
+	gt.B(t, strings.Contains(s, "## Comments")).False()
 }
 
 func TestIssuer(t *testing.T) {

--- a/pkg/action/github/issuer_test.go
+++ b/pkg/action/github/issuer_test.go
@@ -63,7 +63,7 @@ func TestIssueTemplate(t *testing.T) {
 	gt.B(t, strings.Contains(s, "### md-title")).True()
 	gt.B(t, strings.Contains(s, "*md-test*")).True()
 
-	os.WriteFile("test.md", []byte(s), 0644)
+	// os.WriteFile("test.md", []byte(s), 0644)
 }
 
 func TestIssueTemplateNoMarkdown(t *testing.T) {

--- a/pkg/domain/types/parameter.go
+++ b/pkg/domain/types/parameter.go
@@ -11,4 +11,5 @@ const (
 	DomainName ParameterType = "domain"
 	FileSha256 ParameterType = "file.sha256"
 	FileSha512 ParameterType = "file.sha512"
+	MarkDown   ParameterType = "markdown"
 )


### PR DESCRIPTION
# Why

Some actions are expected to return text style data. However, it is not appropriate to display those texts side by side with other parameters in the same way. Therefore, we need a way to distinguish them.

# Changes

- Add `markdown` type
- Update template of `github-issuer` to separate view of `markdown` and others