### PR TITLE
Add http.fetch action

### DIFF
--- a/pkg/action/README.md
+++ b/pkg/action/README.md
@@ -3,3 +3,4 @@
 - [github](./github/)
 - [chatgpt](./chatgpt/)
 - [slack](./slack/)
+- [http](./http)

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -3,6 +3,7 @@ package action
 import (
 	"github.com/m-mizutani/alertchain/pkg/action/chatgpt"
 	"github.com/m-mizutani/alertchain/pkg/action/github"
+	"github.com/m-mizutani/alertchain/pkg/action/http"
 	"github.com/m-mizutani/alertchain/pkg/action/slack"
 	"github.com/m-mizutani/alertchain/pkg/domain/interfaces"
 	"github.com/m-mizutani/alertchain/pkg/domain/types"
@@ -12,6 +13,7 @@ var actionMap = map[types.ActionName]interfaces.RunAction{
 	"github.create_issue":   github.CreateIssue,
 	"chatgpt.comment_alert": chatgpt.CommentAlert,
 	"slack.post":            slack.Post,
+	"http.fetch":            http.Fetch,
 }
 
 func Map() map[types.ActionName]interfaces.RunAction {

--- a/pkg/action/http/README.md
+++ b/pkg/action/http/README.md
@@ -1,0 +1,40 @@
+# HTTP
+
+## `http.fetch`
+
+This action fetches data from the specified URL using the specified HTTP method and returns the result.
+
+### Arguments
+
+Example policy:
+
+```rego
+run[res] {
+  res := {
+    id: "your-action",
+    uses: "http.fetch",
+    args: {
+      "method": "GET",
+      "url": "https://api.example.com/data",
+      "header": {
+        "Authorization": "Bearer " + input.env.API_TOKEN,
+      },
+    },
+  },
+}
+```
+
+- `method` (string, required): Specifies the HTTP method to use for the request (e.g., "GET", "POST", "PUT", "DELETE").
+- `url` (string, required): Specifies the URL to fetch the data from.
+- `header` (map of strings, optional): Specifies the HTTP headers to include in the request.
+- `data` (string, optional): Specifies the request body to include in the request (for methods like "POST" and "PUT").
+
+### Response
+
+The response depends on the `Content-Type` of the HTTP response. The following content types are supported:
+
+- `application/json`: The response body will be parsed as JSON and returned as an object.
+- `application/octet-stream`: The response body will be returned as a byte array.
+- Other content types: The response body will be returned as a string.
+
+In case of an error while making the HTTP request or processing the response, an error will be returned.

--- a/pkg/action/http/fetch.go
+++ b/pkg/action/http/fetch.go
@@ -1,0 +1,67 @@
+package http
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/m-mizutani/alertchain/pkg/domain/model"
+	"github.com/m-mizutani/alertchain/pkg/domain/types"
+	"github.com/m-mizutani/goerr"
+)
+
+func Fetch(ctx *model.Context, _ model.Alert, args model.ActionArgs) (any, error) {
+	method, ok := args["method"].(string)
+	if !ok {
+		return nil, goerr.Wrap(types.ErrActionInvalidArgument, "method is required")
+	}
+
+	url, ok := args["url"].(string)
+	if !ok {
+		return nil, goerr.Wrap(types.ErrActionInvalidArgument, "url is required")
+	}
+
+	var reqBody io.Reader
+	if data, ok := args["data"].(string); ok {
+		reqBody = strings.NewReader(data)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, reqBody)
+	if err != nil {
+		return nil, goerr.Wrap(err, "Fail to create HTTP request")
+	}
+
+	if v, ok := args["header"].(map[string]string); ok {
+		for k, v := range v {
+			req.Header.Add(k, v)
+		}
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, goerr.Wrap(err, "Fail to send HTTP request")
+	}
+	defer resp.Body.Close()
+
+	var result any
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, goerr.Wrap(err, "Fail to read HTTP response body")
+	}
+
+	switch resp.Header.Get("Content-Type") {
+	case "application/json":
+		if err := json.Unmarshal(respBody, &result); err != nil {
+			return nil, goerr.Wrap(err, "Fail to parse JSON response")
+		}
+
+	case "application/octet-stream":
+		result = respBody
+
+	default:
+		result = string(respBody)
+	}
+
+	return result, nil
+}

--- a/pkg/action/http/fetch.go
+++ b/pkg/action/http/fetch.go
@@ -42,7 +42,11 @@ func Fetch(ctx *model.Context, _ model.Alert, args model.ActionArgs) (any, error
 	if err != nil {
 		return nil, goerr.Wrap(err, "Fail to send HTTP request")
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			ctx.Logger().Warn("Fail to close HTTP response body", "err", err)
+		}
+	}()
 
 	var result any
 	respBody, err := io.ReadAll(resp.Body)

--- a/pkg/action/http/fetch_test.go
+++ b/pkg/action/http/fetch_test.go
@@ -17,7 +17,7 @@ func TestFetch(t *testing.T) {
 			gt.Value(t, r.Method).Equal("GET")
 			gt.Value(t, r.URL.Path).Equal("/test")
 			w.Header().Add("Content-Type", "application/json")
-			w.Write([]byte(`{"message":"Hello"}`))
+			gt.R1(w.Write([]byte(`{"message":"Hello"}`))).NoError(t)
 		}))
 		defer ts.Close()
 
@@ -50,7 +50,7 @@ func TestFetch(t *testing.T) {
 	t.Run("Invalid JSON response", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Add("Content-Type", "application/json")
-			w.Write([]byte(`{"message"}`))
+			gt.R1(w.Write([]byte(`{"message"}`))).NoError(t)
 		}))
 		defer ts.Close()
 

--- a/pkg/action/http/fetch_test.go
+++ b/pkg/action/http/fetch_test.go
@@ -1,0 +1,81 @@
+package http_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	httpaction "github.com/m-mizutani/alertchain/pkg/action/http"
+	"github.com/m-mizutani/alertchain/pkg/domain/model"
+	"github.com/m-mizutani/gt"
+)
+
+func TestFetch(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gt.Value(t, r.Method).Equal("GET")
+			gt.Value(t, r.URL.Path).Equal("/test")
+			w.Header().Add("Content-Type", "application/json")
+			w.Write([]byte(`{"message":"Hello"}`))
+		}))
+		defer ts.Close()
+
+		ctx := &model.Context{
+			Context: context.Background(),
+		}
+
+		args := model.ActionArgs{
+			"method": "GET",
+			"url":    ts.URL + "/test",
+		}
+
+		result := gt.R1(httpaction.Fetch(ctx, model.Alert{}, args)).NoError(t)
+
+		res := gt.Cast[map[string]interface{}](t, result)
+
+		gt.Value(t, res["message"].(string)).Equal("Hello")
+	})
+
+	t.Run("Invalid argument", func(t *testing.T) {
+		ctx := &model.Context{
+			Context: context.Background(),
+		}
+
+		args := model.ActionArgs{}
+
+		gt.R1(httpaction.Fetch(ctx, model.Alert{}, args)).Error(t)
+	})
+
+	t.Run("Invalid JSON response", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Add("Content-Type", "application/json")
+			w.Write([]byte(`{"message"}`))
+		}))
+		defer ts.Close()
+
+		ctx := &model.Context{
+			Context: context.Background(),
+		}
+
+		args := model.ActionArgs{
+			"method": "GET",
+			"url":    ts.URL + "/test",
+		}
+
+		gt.R1(httpaction.Fetch(ctx, model.Alert{}, args)).Error(t)
+	})
+
+	t.Run("HTTP request error", func(t *testing.T) {
+		ctx := &model.Context{
+			Context: context.Background(),
+		}
+
+		args := model.ActionArgs{
+			"method": "GET",
+			"url":    "http://example.invalid",
+		}
+
+		gt.R1(httpaction.Fetch(ctx, model.Alert{}, args)).Error(t)
+	})
+}


### PR DESCRIPTION
# Why

Most of API integration is used via HTTP. Then generic HTTP action can cover many use cases.

# Changes

- Add `http.fetch` acton