### PR TITLE
Add otx.indicator action

### DIFF
--- a/pkg/action/README.md
+++ b/pkg/action/README.md
@@ -4,3 +4,4 @@
 - [chatgpt](./chatgpt/)
 - [slack](./slack/)
 - [http](./http)
+- [otx](./otx)

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -4,6 +4,7 @@ import (
 	"github.com/m-mizutani/alertchain/pkg/action/chatgpt"
 	"github.com/m-mizutani/alertchain/pkg/action/github"
 	"github.com/m-mizutani/alertchain/pkg/action/http"
+	"github.com/m-mizutani/alertchain/pkg/action/otx"
 	"github.com/m-mizutani/alertchain/pkg/action/slack"
 	"github.com/m-mizutani/alertchain/pkg/domain/interfaces"
 	"github.com/m-mizutani/alertchain/pkg/domain/types"
@@ -14,6 +15,7 @@ var actionMap = map[types.ActionName]interfaces.RunAction{
 	"chatgpt.comment_alert": chatgpt.CommentAlert,
 	"slack.post":            slack.Post,
 	"http.fetch":            http.Fetch,
+	"otx.indicator":         otx.Indicator,
 }
 
 func Map() map[types.ActionName]interfaces.RunAction {

--- a/pkg/action/otx/README.md
+++ b/pkg/action/otx/README.md
@@ -1,0 +1,166 @@
+# OTX
+
+Actions for AlienVault OTX (Open Threat Exchange) API.
+
+## `otx.indicator`
+
+This action retrieves information about the specified indicator from the AlienVault OTX API.
+
+### Prerequisite
+
+You need an AlienVault OTX API key. You can sign up for a free account and get an API key [here](https://otx.alienvault.com/).
+
+### Arguments
+
+Example policy:
+
+```rego
+run[res] {
+  res := {
+    id: "your-action",
+    uses: "otx.indicator",
+    args: {
+      "secret_api_key": input.env.OTX_API_KEY,
+      "type": "domain",
+      "indicator": "example.com",
+      "section": "general",
+    },
+  },
+}
+```
+
+- `secret_api_key` (string, required): Specifies the AlienVault OTX API key.
+- `type` (string, required): Specifies the indicator type. Must be one of "ipv4", "ipv6", "domain", "hostname", "file", or "url".
+- `indicator` (string, required): Specifies the indicator value to be queried.
+- `section` (string, required): Specifies the section of information to be retrieved. Must be one of "general", "reputation", "geo", "malware", "url_list", "passive_dns", or "http_scans".
+
+### Response
+
+The response is a JSON object containing the requested information about the indicator. The structure of the JSON object depends on the specified section. For more information, see the [AlienVault OTX API documentation](https://otx.alienvault.com/assets/static/external_api.html).
+
+**Example**
+
+```json
+{
+  "whois": "http://whois.domaintools.com/192.0.2.1",
+  "reputation": 0,
+  "indicator": "192.0.2.1",
+  "type": "IPv4",
+  "type_title": "IPv4",
+  "base_indicator": {
+    "id": 99999999,
+    "indicator": "192.0.2.1",
+    "type": "IPv4",
+    "title": "",
+    "description": "",
+    "content": "",
+    "access_type": "public",
+    "access_reason": ""
+  },
+  "pulse_info": {
+    "count": 29,
+    "pulses": [
+      {
+        "id": "xxxxxxxxxxxxxxx",
+        "name": "IP Addresses Logged by the Rosethorn PotNet",
+        "description": "Malicious activity detections from a small network of honeypots that spans multiple ISPs and geographic locations.\n\nBehavior is logged on ports 23, 80, 3306, and 5900.",
+        "modified": "2023-05-13T00:18:43.306000",
+        "created": "2023-03-27T16:17:36.094000",
+        "tags": [],
+        "references": [],
+        "public": 1,
+        "adversary": "",
+        "targeted_countries": [
+          "United States of America"
+        ],
+        "malware_families": [],
+        "attack_ids": [],
+        "industries": [],
+        "TLP": "green",
+        "cloned_from": null,
+        "export_count": 46,
+        "upvotes_count": 0,
+        "downvotes_count": 0,
+        "votes_count": 0,
+        "locked": false,
+        "pulse_source": "web",
+        "validator_count": 0,
+        "comment_count": 0,
+        "follower_count": 0,
+        "vote": 0,
+        "author": {
+          "username": "xxxxx",
+          "id": "1111111",
+          "avatar_url": "/otxapi/users/avatar_image/media/avatars/user_217809/resized/80/avatar_3b9c358f36.png",
+          "is_subscribed": false,
+          "is_following": false
+        },
+        "indicator_type_counts": {
+          "IPv4": 31038
+        },
+        "indicator_count": 31038,
+        "is_author": false,
+        "is_subscribing": null,
+        "subscriber_count": 82,
+        "modified_text": "4 minutes ago ",
+        "is_modified": true,
+        "groups": [],
+        "in_group": false,
+        "threat_hunter_scannable": true,
+        "threat_hunter_has_agents": 1,
+        "related_indicator_type": "IPv4",
+        "related_indicator_is_active": 1
+      }
+    ],
+    "references": [],
+    "related": {
+      "alienvault": {
+        "adversary": [],
+        "malware_families": [],
+        "industries": []
+      },
+      "other": {
+        "adversary": [],
+        "malware_families": [],
+        "industries": [
+          "Government",
+          "Industrial",
+          "Defense"
+        ]
+      }
+    }
+  },
+  "false_positive": [],
+  "validation": [],
+  "asn": "AS29529 itecom bvba",
+  "city_data": true,
+  "city": null,
+  "region": null,
+  "continent_code": "EU",
+  "country_code3": "BEL",
+  "country_code2": "BE",
+  "subdivision": null,
+  "latitude": 50.8509,
+  "postal_code": null,
+  "longitude": 4.3447,
+  "accuracy_radius": 100,
+  "country_code": "BE",
+  "country_name": "Belgium",
+  "dma_code": 0,
+  "charset": 0,
+  "area_code": 0,
+  "flag_url": "/assets/images/flags/be.png",
+  "flag_title": "Belgium",
+  "sections": [
+    "general",
+    "geo",
+    "reputation",
+    "url_list",
+    "passive_dns",
+    "malware",
+    "nids_list",
+    "http_scans"
+  ]
+}
+
+```

--- a/pkg/action/otx/action.go
+++ b/pkg/action/otx/action.go
@@ -1,1 +1,98 @@
 package otx
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/m-mizutani/alertchain/pkg/domain/model"
+	"github.com/m-mizutani/alertchain/pkg/domain/types"
+	"github.com/m-mizutani/goerr"
+)
+
+func ReplaceHTTPClient(client *http.Client) {
+	httpClient = client
+}
+
+var httpClient = http.DefaultClient
+
+func Indicator(ctx *model.Context, _ model.Alert, args model.ActionArgs) (any, error) {
+	api_key, ok := args["secret_api_key"].(string)
+	if !ok {
+		return nil, goerr.Wrap(types.ErrActionInvalidArgument, "secret_api_key is required")
+	}
+
+	indicatorType, ok := args["type"].(string)
+	if !ok {
+		return nil, goerr.Wrap(types.ErrActionInvalidArgument, "type is required")
+	}
+	if !isValidType(indicatorType) {
+		return nil, goerr.Wrap(types.ErrActionInvalidArgument, "type must be one of ipv4, ipv6, domain, hostname, file, url")
+	}
+
+	indicator, ok := args["indicator"].(string)
+	if !ok {
+		return nil, goerr.Wrap(types.ErrActionInvalidArgument, "indicator is required")
+	}
+
+	section, ok := args["section"].(string)
+	if !ok {
+		return nil, goerr.Wrap(types.ErrActionInvalidArgument, "section is required")
+	}
+	if !isValidSection(section) {
+		return nil, goerr.Wrap(types.ErrActionInvalidArgument, "section must be one of general, reputation, geo, malware, url_list, passive_dns, http_scans")
+	}
+
+	url := "https://otx.alienvault.com/api/v1/indicators/" + indicatorType + "/" + indicator + "/" + section
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, goerr.Wrap(err, "Fail to create HTTP request for OTX")
+	}
+	req.Header.Set("X-OTX-API-KEY", api_key)
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, goerr.Wrap(err, "Fail to send HTTP request to OTX")
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			ctx.Logger().Warn("Fail to close HTTP response body", "err", err)
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, goerr.Wrap(types.ErrActionFailed, "OTX returns non-200 status code").With("status", resp.StatusCode).With("url", url).With("body", string(body))
+	}
+
+	var result any
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, goerr.Wrap(err, "Fail to read HTTP response body from OTX")
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, goerr.Wrap(err, "Fail to parse JSON response from OTX").With("body", string(respBody))
+	}
+
+	return result, nil
+}
+
+func isValidSection(section string) bool {
+	sections := []string{"general", "reputation", "geo", "malware", "url_list", "passive_dns", "http_scans"}
+	for _, s := range sections {
+		if section == s {
+			return true
+		}
+	}
+	return false
+}
+
+func isValidType(t string) bool {
+	categories := []string{"IPv4", "IPv6", "domain", "hostname", "file", "url"}
+	for _, c := range categories {
+		if t == c {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/action/otx/action_test.go
+++ b/pkg/action/otx/action_test.go
@@ -1,0 +1,147 @@
+package otx_test
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/m-mizutani/alertchain/pkg/action/otx"
+	"github.com/m-mizutani/alertchain/pkg/domain/model"
+	"github.com/m-mizutani/alertchain/pkg/domain/types"
+	"github.com/m-mizutani/gt"
+)
+
+func TestIndicator(t *testing.T) {
+	testCases := []struct {
+		title      string
+		httpClient *http.Client
+		args       model.ActionArgs
+		hasErr     bool
+		errType    error
+	}{
+		{
+			title: "normal",
+			httpClient: mockHTTPClient(func(req *http.Request) *http.Response {
+				respJSON := `{"key": "value"}`
+				return &http.Response{
+					StatusCode: 200,
+					Body:       io.NopCloser(bytes.NewReader([]byte(respJSON))),
+					Header:     make(http.Header),
+				}
+			}),
+			args: model.ActionArgs{
+				"secret_api_key": "dummy",
+				"type":           "domain",
+				"indicator":      "example.com",
+				"section":        "general",
+			},
+			hasErr: false,
+		},
+		{
+			title: "invalid api key",
+			args: model.ActionArgs{
+				"type":      "domain",
+				"indicator": "example.com",
+				"section":   "general",
+			},
+			hasErr:  true,
+			errType: types.ErrActionInvalidArgument,
+		},
+		{
+			title: "invalid type",
+			args: model.ActionArgs{
+				"secret_api_key": "dummy",
+				"type":           "invalid",
+				"indicator":      "example.com",
+				"section":        "general",
+			},
+			hasErr:  true,
+			errType: types.ErrActionInvalidArgument,
+		},
+		{
+			title: "invalid section",
+			args: model.ActionArgs{
+				"secret_api_key": "dummy",
+				"type":           "domain",
+				"indicator":      "example.com",
+				"section":        "invalid",
+			},
+			hasErr:  true,
+			errType: types.ErrActionInvalidArgument,
+		},
+		{
+			title: "http request error",
+			httpClient: mockHTTPClient(func(req *http.Request) *http.Response {
+				return &http.Response{
+					StatusCode: 500,
+					Body:       io.NopCloser(bytes.NewReader([]byte(""))),
+					Header:     make(http.Header),
+				}
+			}),
+			args: model.ActionArgs{
+				"secret_api_key": "dummy",
+				"type":           "domain",
+				"indicator":      "example.com",
+				"section":        "general",
+			},
+			hasErr: true,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.title, func(t *testing.T) {
+			if tt.httpClient != nil {
+				otx.ReplaceHTTPClient(tt.httpClient)
+				t.Cleanup(func() {
+					otx.ReplaceHTTPClient(http.DefaultClient)
+				})
+			}
+
+			ctx := model.NewContext()
+			result, err := otx.Indicator(ctx, model.Alert{}, tt.args)
+
+			if tt.hasErr {
+				gt.Error(t, err).Must()
+				if tt.errType != nil {
+					gt.Error(t, err).Is(tt.errType)
+				}
+			} else {
+				gt.NoError(t, err).Must()
+				gt.V(t, result).NotNil()
+			}
+		})
+	}
+}
+
+func mockHTTPClient(doFunc func(*http.Request) *http.Response) *http.Client {
+	return &http.Client{
+		Transport: mockRoundTripper(doFunc),
+	}
+}
+
+type mockRoundTripper func(*http.Request) *http.Response
+
+func (mrt mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return mrt(req), nil
+}
+
+func TestIndicatorRun(t *testing.T) {
+	apiKey := os.Getenv("TEST_OTX_API_KEY")
+	if apiKey == "" {
+		t.Skip("TEST_OTX_API_KEY is not set")
+	}
+
+	ctx := model.NewContext()
+	args := model.ActionArgs{
+		"secret_api_key": apiKey,
+		"type":           "IPv4",
+		"indicator":      "87.236.176.4",
+		"section":        "general",
+	}
+
+	result, err := otx.Indicator(ctx, model.Alert{}, args)
+	gt.NoError(t, err).Must()
+	gt.V(t, result).NotNil()
+}

--- a/pkg/domain/types/error.go
+++ b/pkg/domain/types/error.go
@@ -40,4 +40,5 @@ var (
 	// runtime errors
 	ErrMaxStackDepth  = newError("max stack depth")
 	ErrActionNotFound = newError("action not found")
+	ErrActionFailed   = newError("action failed")
 )


### PR DESCRIPTION
This pull request adds a new action called `otx.indicator` which retrieves information about a specified indicator from the AlienVault OTX (Open Threat Exchange) API.

The action requires the following arguments:
- `secret_api_key`: The AlienVault OTX API key.
- `type`: The indicator type, which must be one of "ipv4", "ipv6", "domain", "hostname", "file", or "url".
- `indicator`: The indicator value to be queried.
- `section`: The section of information to be retrieved, which must be one of "general", "reputation", "geo", "malware", "url_list", "passive_dns", or "http_scans".

The response from the action is a JSON object containing the requested information about the indicator. The structure of the JSON object depends on the specified section. For more information, see the [AlienVault OTX API documentation](https://otx.alienvault.com/assets/static/external_api.html).