### PR TITLE
fix(play): log flush must be triggered in cli

### DIFF
--- a/pkg/chain/workflow.go
+++ b/pkg/chain/workflow.go
@@ -29,7 +29,6 @@ func newWorkflow(c *core.Core, alert model.Alert) (*workflow, error) {
 func (x *workflow) Run(ctx *model.Context) error {
 	copied := x.alert.Copy()
 	logger := x.core.ScenarioLogger().NewAlertLogger(&copied)
-	defer x.core.ScenarioLogger().Flush()
 
 	envVars := x.core.Env()
 

--- a/pkg/chain/workflow_test.go
+++ b/pkg/chain/workflow_test.go
@@ -57,6 +57,7 @@ func TestWorkflow(t *testing.T) {
 
 	wf := gt.R1(chain.NewWorkflow(c, alert)).NoError(t)
 	gt.NoError(t, wf.Run(ctx))
+	recorder.Flush()
 
 	var log model.ScenarioLog
 	gt.NoError(t, json.NewDecoder(bytes.NewReader(buf.Bytes())).Decode(&log))


### PR DESCRIPTION
By flushing log in workflow, output format will be broken