### PR TITLE
Update firestore collection prefix to firestore database ID

### DIFF
--- a/pkg/controller/cli/config/database.go
+++ b/pkg/controller/cli/config/database.go
@@ -14,7 +14,7 @@ import (
 type Database struct {
 	dbType              string
 	firestoreProjectID  string
-	firestoreCollection string
+	firestoreDatabaseID string
 }
 
 func (x *Database) Flags() []cli.Flag {
@@ -38,11 +38,11 @@ func (x *Database) Flags() []cli.Flag {
 			Destination: &x.firestoreProjectID,
 		},
 		&cli.StringFlag{
-			Name:        "firestore-collection-prefix",
-			Usage:       "Prefix of Firestore collection name. Actual collection names will be <prefix>.attr, <prefix>.workflow",
+			Name:        "firestore-database-id",
+			Usage:       "Prefix of Firestore database ID",
 			Category:    category,
-			EnvVars:     []string{"ALERTCHAIN_FIRESTORE_COLLECTION_PREFIX"},
-			Destination: &x.firestoreCollection,
+			EnvVars:     []string{"ALERTCHAIN_FIRESTORE_DATABASE_ID"},
+			Destination: &x.firestoreDatabaseID,
 		},
 	}
 }
@@ -58,11 +58,11 @@ func (x *Database) New(ctx *model.Context) (interfaces.Database, func(), error) 
 		if x.firestoreProjectID == "" {
 			return nil, nopCloser, goerr.Wrap(types.ErrInvalidOption, "firestore-project-id is required for firestore")
 		}
-		if x.firestoreCollection == "" {
+		if x.firestoreDatabaseID == "" {
 			return nil, nopCloser, goerr.Wrap(types.ErrInvalidOption, "firestore-collection-prefix is required for firestore")
 		}
 
-		client, err := firestore.New(ctx, x.firestoreProjectID, x.firestoreCollection)
+		client, err := firestore.New(ctx, x.firestoreProjectID, x.firestoreDatabaseID)
 		if err != nil {
 			return nil, nopCloser, goerr.Wrap(err, "failed to initialize firestore client")
 		}

--- a/pkg/infra/firestore/client.go
+++ b/pkg/infra/firestore/client.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/firestore"
-	firebase "firebase.google.com/go"
+
 	"github.com/m-mizutani/alertchain/pkg/domain/interfaces"
 	"github.com/m-mizutani/alertchain/pkg/domain/model"
 	"github.com/m-mizutani/alertchain/pkg/domain/types"
@@ -23,6 +23,7 @@ import (
 type Client struct {
 	client             *firestore.Client
 	projectID          string
+	databaseID         string
 	attrCollection     string
 	workflowCollection string
 }
@@ -296,23 +297,18 @@ func (x *Client) Unlock(ctx *model.Context, ns types.Namespace) error {
 	return nil
 }
 
-func New(ctx *model.Context, projectID string, collectionPrefix string) (*Client, error) {
-	conf := &firebase.Config{ProjectID: projectID}
-	app, err := firebase.NewApp(ctx, conf)
+func New(ctx *model.Context, projectID string, databaseID string) (*Client, error) {
+	client, err := firestore.NewClientWithDatabase(ctx, projectID, databaseID)
 	if err != nil {
 		return nil, types.AsRuntimeErr(goerr.Wrap(err, "Failed to initialize firebase app"))
-	}
-
-	client, err := app.Firestore(ctx)
-	if err != nil {
-		return nil, types.AsRuntimeErr(goerr.Wrap(err, "Failed to initialize firestore client"))
 	}
 
 	return &Client{
 		client:             client,
 		projectID:          projectID,
-		attrCollection:     collectionPrefix + ".attr",
-		workflowCollection: collectionPrefix + ".workflow",
+		databaseID:         databaseID,
+		attrCollection:     "attrs",
+		workflowCollection: "workflows",
 	}, nil
 }
 

--- a/pkg/infra/firestore/client_test.go
+++ b/pkg/infra/firestore/client_test.go
@@ -14,20 +14,20 @@ import (
 
 func TestWorkflow(t *testing.T) {
 	var (
-		projectID string
-		colPrefix string
+		projectID  string
+		databaseID string
 	)
 
 	if err := utils.LoadEnv(
 		utils.Env("TEST_FIRESTORE_PROJECT_ID", &projectID),
-		utils.Env("TEST_FIRESTORE_COLLECTION_PREFIX", &colPrefix),
+		utils.Env("TEST_FIRESTORE_DATABASE_ID", &databaseID),
 	); err != nil {
 		t.Skipf("Skip test due to missing env: %v", err)
 	}
 
 	ctx := model.NewContext()
 	now := time.Now()
-	client := gt.R1(firestore.New(ctx, projectID, colPrefix)).NoError(t)
+	client := gt.R1(firestore.New(ctx, projectID, databaseID)).NoError(t)
 
 	workflow0 := model.WorkflowRecord{
 		ID:        types.NewWorkflowID(),


### PR DESCRIPTION
# Why

Firebase started to support multiple databases in one Google Cloud Project. From view of authorization management, alertchain database should be separated from others.

# Changes

- Obsoleted collection name prefix option
- Add database ID option
- Use firestore.NewClientWithDatabase to create a new client