### PR TITLE
Add alert raw data to alert model and chain package tests

### DIFF
--- a/docs/policy.md
+++ b/docs/policy.md
@@ -206,6 +206,8 @@ After evaluating the action policy, if the next action is required, set the `act
 - `attrs` (array, optional): Array of [Attribute](#Attribute)
 - `refs` (array, optional): Array of [Reference](#Reference)
 - `namespace` (string, optional): Namespace of Attributes (attrs). Global attributes are shared among alerts and actions that have the same namespace. If not set, global attribute feature is not enabled.
+- `data` (any): Original data of the alert
+- `raw` (string): Pretty-printed JSON string of the alert data
 
 ### Attribute
 

--- a/pkg/chain/alert_test.go
+++ b/pkg/chain/alert_test.go
@@ -1,0 +1,51 @@
+package chain_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/m-mizutani/alertchain/pkg/chain"
+	"github.com/m-mizutani/alertchain/pkg/chain/core"
+	"github.com/m-mizutani/alertchain/pkg/domain/model"
+	"github.com/m-mizutani/alertchain/pkg/infra/policy"
+	"github.com/m-mizutani/gt"
+)
+
+func TestAlertRaw(t *testing.T) {
+	alertData := `{"color": "blue"}`
+	var alertDataPP bytes.Buffer
+	enc := json.NewEncoder(&alertDataPP)
+	enc.SetIndent("", "  ")
+	gt.NoError(t, enc.Encode(alertData))
+
+	alertPolicy := gt.R1(policy.New(
+		policy.WithPackage("alert"),
+		policy.WithFile("testdata/alert_feature/alert.rego"),
+		policy.WithReadFile(read),
+	)).NoError(t)
+
+	actionPolicy := gt.R1(policy.New(
+		policy.WithPackage("action"),
+		policy.WithFile("testdata/alert_feature/action.rego"),
+		policy.WithReadFile(read),
+	)).NoError(t)
+
+	var calledMock int
+	mock := func(ctx *model.Context, alert model.Alert, args model.ActionArgs) (any, error) {
+		s := gt.Cast[string](t, args["raw"])
+		gt.V(t, s).Equal(alertDataPP.String())
+		calledMock++
+		return nil, nil
+	}
+
+	c := gt.R1(chain.New(
+		core.WithPolicyAlert(alertPolicy),
+		core.WithPolicyAction(actionPolicy),
+		core.WithExtraAction("test.output_raw", mock),
+	)).NoError(t)
+
+	ctx := model.NewContext()
+	gt.R1(c.HandleAlert(ctx, "amber", alertData)).NoError(t)
+	gt.N(t, calledMock).Equal(1)
+}

--- a/pkg/chain/testdata/alert_feature/action.rego
+++ b/pkg/chain/testdata/alert_feature/action.rego
@@ -1,0 +1,12 @@
+package action
+
+run[job] {
+    input.seq == 0
+
+    job := {
+        "uses": "test.output_raw",
+        "args": {
+            "raw": input.alert.raw,
+        }
+    }
+}

--- a/pkg/chain/testdata/alert_feature/alert.rego
+++ b/pkg/chain/testdata/alert_feature/alert.rego
@@ -1,0 +1,7 @@
+package alert.amber
+
+alert[res] {
+    res := {
+        "title": "Amber Alert",
+    }
+}

--- a/pkg/domain/model/alert.go
+++ b/pkg/domain/model/alert.go
@@ -37,7 +37,8 @@ type Alert struct {
 	Data      any           `json:"data"`
 	CreatedAt time.Time     `json:"created_at"`
 
-	Raw string `json:"-"`
+	// Raw is a JSON string of Data. The field will be redacted by masq because of verbosity.
+	Raw string `json:"raw" masq:"quiet"`
 }
 
 func (x Alert) Copy() Alert {

--- a/pkg/utils/logger.go
+++ b/pkg/utils/logger.go
@@ -32,6 +32,7 @@ func Logger() *slog.Logger {
 func ReconfigureLogger(w io.Writer, level slog.Level, format LogFormat) {
 	filter := masq.New(
 		masq.WithTag("secret"),
+		masq.WithTag("quiet"),
 		masq.WithFieldPrefix("secret_"),
 		masq.WithAllowedType(reflect.TypeOf(time.Time{})),
 	)


### PR DESCRIPTION
# Changes

- Add `raw` field to `Alert` data structure to deliver pretty printed original alert data
- Add test to represent `raw` field in action policy